### PR TITLE
Fix Series.minus error in ADX calculation

### DIFF
--- a/tsla_backtest_relaxed.py
+++ b/tsla_backtest_relaxed.py
@@ -37,7 +37,7 @@ def manual_adx(df: pd.DataFrame, length: int) -> pd.Series:
     atr_len = atr(df, length)
     plusDI = 100 * rma(pd.Series(plusDM, index=df.index), length) / atr_len.replace(0, np.nan)
     minusDI = 100 * rma(pd.Series(minusDM, index=df.index), length) / atr_len.replace(0, np.nan)
-    dx = 100 * (plusDI.minus(minusDI).abs() / (plusDI + minusDI).replace(0, np.nan))
+    dx = 100 * (plusDI.sub(minusDI).abs() / (plusDI + minusDI).replace(0, np.nan))
     return rma(dx.fillna(0), length)
 
 def macd_hist(close: pd.Series, fast=12, slow=26, sig=9) -> Tuple[pd.Series, pd.Series, pd.Series]:


### PR DESCRIPTION
## Summary
- use pandas Series.sub instead of nonexistent Series.minus in manual_adx

## Testing
- `python -m py_compile tsla_backtest_relaxed.py live_strategy_engine.py`
- `python - <<'PY'
import pandas as pd, numpy as np
from tsla_backtest_relaxed import manual_adx
np.random.seed(0); n=100
idx=pd.date_range('2024-01-01', periods=n, freq='T')
close=pd.Series(np.random.rand(n)*100+200, index=idx)
open_=close+np.random.randn(n)
high=open_+np.random.rand(n)
low=open_-np.random.rand(n)
vol=pd.Series(np.random.randint(1000,5000,n), index=idx)
df=pd.DataFrame({'Open':open_,'High':high,'Low':low,'Close':close,'Volume':vol})
manual_adx(df,14)
PY`

------
https://chatgpt.com/codex/tasks/task_b_68a49c68d678832082fecae65b703b32