### PR TITLE
Fix market hours display in terminal monitor

### DIFF
--- a/tsla_trading_bot.py
+++ b/tsla_trading_bot.py
@@ -250,9 +250,13 @@ class TSLATradingBot:
             
             # Analyze market conditions
             market_conditions = self.strategy_engine.analyze_market_conditions(data_with_indicators)
-            
-            # Update terminal with market conditions
-            self.terminal_monitor.update_market_status(market_conditions)
+
+            # Combine with market status (e.g., market hours) from data manager
+            market_status = self.data_manager.get_market_status()
+            market_status.update(market_conditions)
+
+            # Update terminal with combined market status
+            self.terminal_monitor.update_market_status(market_status)
             
             # Get current price
             current_price = self.data_manager.current_price or market_conditions.get('current_price', 0)


### PR DESCRIPTION
## Summary
- Merge DataManager market status with strategy engine analysis so terminal monitor shows correct market hours

## Testing
- `python 'Test script to validate TSLA Trading Bot setup'` *(fails: Error fetching current price; Cannot set a DataFrame with multiple columns to the single column VWAP)*
- `python - <<'PY'
import pandas as pd
from datetime import datetime
from tsla_trading_bot import TSLATradingBot, BotConfig
class DummyDataManager:
    def __init__(self):
        self.current_price = 123.45
    def get_market_status(self):
        return {'is_market_hours': True, 'current_price': self.current_price}
class DummyStrategyEngine:
    def compute_indicators(self, df):
        return df
    def analyze_market_conditions(self, df):
        return {'current_price': 123.45, 'trend_quality': 'Strong', 'volatility_level': 'Normal', 'momentum': 'Bullish', 'rsi': 55, 'trend_strength': 20}
    def generate_signal(self, df, price):
        return None
    def get_position_summary(self):
        return {}
class DummyTerminalMonitor:
    def update_market_status(self, status):
        print('Market status:', status)
    def update_position_status(self, status):
        pass
bot = TSLATradingBot(BotConfig())
bot.data_manager = DummyDataManager()
bot.strategy_engine = DummyStrategyEngine()
bot.terminal_monitor = DummyTerminalMonitor()
bot._update_performance_stats = lambda: None
bot._check_risk_management = lambda: None
market_data = pd.DataFrame({'Open':[1], 'High':[1], 'Low':[1], 'Close':[1], 'Volume':[1]}, index=[datetime.now()])
bot._process_market_data(market_data)
PY`

------
https://chatgpt.com/codex/tasks/task_b_68a49c8c49788320a37c7b14b900f59f