### PR TITLE
Enable live IBKR trading and adjust share size

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ ADX: 28.3
 POSITION STATUS
 -------------------------
 Position: LONG
-Quantity: 10 shares
+Quantity: 3 shares
 Entry Price: $210.00
 Current Price: $215.50
-Unrealized P&L: $55.00
+Unrealized P&L: $16.50
 Stop Loss: $205.00
 Take Profit: $220.00
 
@@ -135,7 +135,7 @@ Current Streak: 2
 ## ⚙️ Configuration Options
 
 ### Trading Parameters
-- **Position Size**: 10 shares per trade (configurable)
+- **Position Size**: 3 shares per trade (configurable)
 - **Risk Management**: ATR-based stops and targets
 - **Daily Limits**: Max trades and loss limits
 - **Strategy**: Multi-indicator confirmation system
@@ -149,7 +149,7 @@ Current Streak: 2
 ## 🔒 Security & Risk Management
 
 ### Built-in Protections
-1. **Position Limits**: Maximum 10 shares per trade
+1. **Position Limits**: Maximum 3 shares per trade
 2. **Daily Limits**: Configurable trade and loss limits
 3. **Stop Losses**: Automatic risk management
 4. **Emergency Stops**: Account-level protection
@@ -157,8 +157,8 @@ Current Streak: 2
 
 ### Recommended Settings for Beginners
 ```env
-ENABLE_TRADING=false        # Start with paper trading
-MAX_POSITION_SIZE=10        # Small position size
+ENABLE_TRADING=true        # Enable live trading
+MAX_POSITION_SIZE=3        # Small position size
 MAX_DAILY_TRADES=3          # Conservative trade limit
 MAX_DAILY_LOSS=200.0        # Reasonable loss limit
 ```
@@ -326,12 +326,12 @@ POLYGON_API_KEY=JlAQap9qJ8F8VrfChiPmYpticVo6SMPO
 
 # IBKR Settings
 IBKR_HOST=127.0.0.1
-IBKR_PORT=7497  # 7497 for paper trading, 7496 for live trading
+IBKR_PORT=7496  # 7496 for live trading, 7497 for paper trading
 IBKR_CLIENT_ID=1
 
 # Trading Settings
-ENABLE_TRADING=false  # Set to true for live trading
-MAX_POSITION_SIZE=10
+ENABLE_TRADING=true  # Set to false for paper trading
+MAX_POSITION_SIZE=3
 MAX_DAILY_TRADES=5
 MAX_DAILY_LOSS=500.0
 
@@ -359,7 +359,7 @@ SESSION_ID=
    - In TWS: File → Global Configuration → API → Settings
    - Enable "Enable ActiveX and Socket Clients"
    - Add "127.0.0.1" to trusted IPs
-   - Set Socket port to 7497 (paper) or 7496 (live)
+   - Set Socket port to 7496 (live) or 7497 (paper)
 
 3. **Login to Paper Trading Account** (recommended for testing)
 
@@ -419,10 +419,10 @@ ADX: 28.3
 POSITION STATUS
 -------------------------
 Position: LONG
-Quantity: 10 shares
+Quantity: 3 shares
 Entry Price: $210.00
 Current Price: $215.50
-Unrealized P&L: $55.00
+Unrealized P&L: $16.50
 Stop Loss: $205.00
 Take Profit: $220.00
 Time in Trade: 15 bars
@@ -467,8 +467,8 @@ The bot uses a sophisticated multi-indicator strategy. Key parameters can be adj
 @dataclass
 class StrategyParams:
     # Position sizing
-    shares_per_trade: int = 10
-    max_position_size: int = 10
+    shares_per_trade: int = 3
+    max_position_size: int = 3
     
     # Risk management
     stop_atr: float = 1.0          # Stop loss in ATR multiples
@@ -490,7 +490,7 @@ class StrategyParams:
 
 Built-in risk management features:
 
-- **Position Sizing**: Fixed 10 shares per trade (configurable)
+- **Position Sizing**: Fixed 3 shares per trade (configurable)
 - **Stop Losses**: ATR-based dynamic stops
 - **Take Profits**: Partial profit taking with trailing stops
 - **Daily Limits**: Maximum trades and loss limits per day
@@ -504,10 +504,10 @@ Always test with paper trading first:
 
 ```bash
 # Set in .env file
-ENABLE_TRADING=false
+ENABLE_TRADING=true
 
 # Or set environment variable
-export ENABLE_TRADING=false
+export ENABLE_TRADING=true
 python tsla_trading_bot.py
 ```
 
@@ -568,7 +568,7 @@ tsla-trading-bot/
 1. **"Connection refused" to IBKR**:
    - Ensure TWS/Gateway is running
    - Check API settings are enabled
-   - Verify port number (7497 for paper, 7496 for live)
+   - Verify port number (7496 for live, 7497 for paper)
 
 2. **"Invalid API key" for Polygon**:
    - Verify your API key is correct

--- a/Test script to validate TSLA Trading Bot setup
+++ b/Test script to validate TSLA Trading Bot setup
@@ -80,8 +80,9 @@ def test_environment_variables():
     
     optional_vars = {
         'IBKR_HOST': 'Interactive Brokers host (default: 127.0.0.1)',
-        'IBKR_PORT': 'Interactive Brokers port (default: 7497)',
-        'ENABLE_TRADING': 'Enable live trading (default: false)',
+        'IBKR_PORT': 'Interactive Brokers port (default: 7496)',
+        'ENABLE_TRADING': 'Enable live trading (default: true)',
+        'MAX_POSITION_SIZE': 'Maximum position size per trade (default: 3)',
     }
     
     all_set = True
@@ -140,7 +141,7 @@ def test_ibkr_connection():
     """Test IBKR connection (optional)"""
     print("\n🏦 Testing IBKR connection...")
     
-    enable_trading = os.getenv('ENABLE_TRADING', 'false').lower() == 'true'
+    enable_trading = os.getenv('ENABLE_TRADING', 'true').lower() == 'true'
     
     if not enable_trading:
         print("⚠️  Trading disabled - Skipping IBKR connection test")
@@ -154,7 +155,7 @@ def test_ibkr_connection():
         
         # Try to connect (with short timeout)
         host = os.getenv('IBKR_HOST', '127.0.0.1')
-        port = int(os.getenv('IBKR_PORT', '7497'))
+        port = int(os.getenv('IBKR_PORT', '7496'))
         
         print(f"   Attempting connection to {host}:{port}...")
         

--- a/ibkr_interface.py
+++ b/ibkr_interface.py
@@ -80,7 +80,7 @@ class IBKRTradingApp(EWrapper, EClient):
         
         # Connection settings
         self.host = "127.0.0.1"
-        self.port = 7497  # TWS Paper Trading port (7496 for live)
+        self.port = 7496  # TWS Live Trading port (7497 for paper)
         self.client_id = 1
         
         # Order management
@@ -101,7 +101,7 @@ class IBKRTradingApp(EWrapper, EClient):
         self.order_callback: Optional[Callable] = None
         self.position_callback: Optional[Callable] = None
         
-    def connect_to_ibkr(self, host: str = "127.0.0.1", port: int = 7497, client_id: int = 1) -> bool:
+    def connect_to_ibkr(self, host: str = "127.0.0.1", port: int = 7496, client_id: int = 1) -> bool:
         """Connect to IBKR TWS or Gateway"""
         try:
             self.host = host
@@ -377,7 +377,7 @@ class IBKRManager:
         self.api_thread = None
         self.running = False
         
-    def start(self, host: str = "127.0.0.1", port: int = 7497, client_id: int = 1) -> bool:
+    def start(self, host: str = "127.0.0.1", port: int = 7496, client_id: int = 1) -> bool:
         """Start IBKR connection"""
         try:
             # Connect to IBKR
@@ -446,7 +446,7 @@ def test_ibkr_connection():
     
     try:
         # Start connection (paper trading port)
-        if manager.start(port=7497):
+        if manager.start(port=7496):
             print("✓ Connected to IBKR successfully")
             
             # Get account info
@@ -463,7 +463,7 @@ def test_ibkr_connection():
             
         else:
             print("✗ Failed to connect to IBKR")
-            print("Make sure TWS or Gateway is running on port 7497")
+            print("Make sure TWS or Gateway is running on port 7496")
             
     except Exception as e:
         print(f"✗ Error testing IBKR: {e}")

--- a/live_strategy_engine.py
+++ b/live_strategy_engine.py
@@ -60,8 +60,8 @@ class Position:
 class StrategyParams:
     """Live trading strategy parameters (relaxed for real trading)"""
     # Position sizing
-    shares_per_trade: int = 10
-    max_position_size: int = 10
+    shares_per_trade: int = 3
+    max_position_size: int = 3
     
     # Risk management
     commission_rate: float = 0.001  # 0.1%

--- a/terminal_monitor.py
+++ b/terminal_monitor.py
@@ -392,10 +392,10 @@ def test_terminal_monitor():
     
     monitor.update_position_status({
         'status': 'LONG',
-        'quantity': 10,
+        'quantity': 3,
         'entry_price': 210.00,
         'current_price': 215.50,
-        'unrealized_pnl': 55.00,
+        'unrealized_pnl': 16.50,
         'stop_loss': 205.00,
         'take_profit': 220.00,
         'bars_in_trade': 15
@@ -403,7 +403,7 @@ def test_terminal_monitor():
     
     # Add some test activity
     monitor.add_signal("BUY", "Pullback + UT Bot signal")
-    monitor.add_trade("BUY", 10, 210.00)
+    monitor.add_trade("BUY", 3, 210.00)
     monitor.add_alert("INFO", "Bot started successfully")
     
     # Update performance stats

--- a/tsla_trading_bot.py
+++ b/tsla_trading_bot.py
@@ -41,12 +41,12 @@ class BotConfig:
     
     # IBKR Settings
     ibkr_host: str = "127.0.0.1"
-    ibkr_port: int = 7497  # Paper trading port
+    ibkr_port: int = 7496  # Live trading port
     ibkr_client_id: int = 1
     
     # Trading Settings
     symbol: str = "TSLA"
-    max_position_size: int = 10
+    max_position_size: int = 3
     enable_trading: bool = True  # Set to False for paper/simulation mode
     
     # Monitoring Settings
@@ -419,6 +419,11 @@ class TSLATradingBot:
             tags="live" if real_trade else "paper",
         )
         self.csv_logger.log_trade(record)
+
+        # Immediately update position display after recording trade
+        self.terminal_monitor.update_position_status(
+            self.strategy_engine.get_position_summary()
+        )
     
     def _check_daily_limits(self, signal) -> bool:
         """Check if daily trading limits allow this trade"""
@@ -556,8 +561,9 @@ def load_config() -> BotConfig:
     # Load from environment variables
     config.polygon_api_key = os.getenv('POLYGON_API_KEY', 'JlAQap9qJ8F8VrfChiPmYpticVo6SMPO')
     config.ibkr_host = os.getenv('IBKR_HOST', '127.0.0.1')
-    config.ibkr_port = int(os.getenv('IBKR_PORT', '7497'))
-    config.enable_trading = os.getenv('ENABLE_TRADING', 'false').lower() == 'true'
+    config.ibkr_port = int(os.getenv('IBKR_PORT', '7496'))
+    config.enable_trading = os.getenv('ENABLE_TRADING', 'true').lower() == 'true'
+    config.max_position_size = int(os.getenv('MAX_POSITION_SIZE', str(config.max_position_size)))
 
     # CSV logging
     config.log_dir = os.getenv('LOG_DIR', './logs')


### PR DESCRIPTION
## Summary
- default to live IBKR trading on port 7496 and expose max position size via environment variables
- reduce share size limits from 10 to 3 across bot and strategy parameters
- update terminal logging to refresh position display immediately after each trade

## Testing
- `python -m py_compile tsla_trading_bot.py live_strategy_engine.py ibkr_interface.py terminal_monitor.py 'Test script to validate TSLA Trading Bot setup'`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a606248e9c8320bb792a8f8fce47fe