### PR TITLE
Fix indentation issue and clean IBKRManager start method

### DIFF
--- a/ibkr_interface.py
+++ b/ibkr_interface.py
@@ -396,7 +396,6 @@ class IBKRManager:
             if not self.app.connect_to_ibkr(host, port, client_id):
                 return False
 
- codex/review-historical-bars-fetching-logic
             # Start API thread
             self.api_thread = threading.Thread(target=self.app.run, daemon=True)
             self.api_thread.start()
@@ -412,23 +411,6 @@ class IBKRManager:
                 logger.error("IBKR connection not established")
                 return False
 
-            # Request initial portfolio updates
-            self.app.request_portfolio_updates()
-
-
-            # Start API processing thread
-            self.api_thread = threading.Thread(target=self.app.run, daemon=True)
-            self.api_thread.start()
-
-            # Wait for connection acknowledgement
-            timeout = time.time() + 10
-            while not self.app.connected and time.time() < timeout:
-                time.sleep(0.1)
-
-            if not self.app.connected:
-                logger.error("Failed to connect to IBKR within timeout")
-                return False
-
             # Request next valid order ID
             self.app.reqIds(-1)
             time.sleep(1)
@@ -437,13 +419,11 @@ class IBKRManager:
             self.app.request_portfolio_updates()
 
             # Start connection monitor thread
-            self.running = True
             self.monitor_thread = threading.Thread(
                 target=self._monitor_connection, daemon=True
             )
             self.monitor_thread.start()
 
- main
             logger.info("IBKR Manager started successfully")
             return True
 


### PR DESCRIPTION
## Summary
- remove stray placeholder lines causing IndentationError
- streamline IBKRManager.start to initialize connection threads cleanly

## Testing
- `python -m py_compile ibkr_interface.py`
- `python -m py_compile tsla_trading_bot.py`
- `python tsla_trading_bot.py` *(fails: HTTPSConnectionPool(host='api.polygon.io', port=443): Max retries exceeded with url)*

------
https://chatgpt.com/codex/tasks/task_b_68a767f42d6883208b8dfcb5e5ee146f