### PR TITLE
Fix IBKR interface instantiation and disambiguate class definitions

### DIFF
--- a/ibkr_interface.py
+++ b/ibkr_interface.py
@@ -520,8 +520,8 @@ class IBKRManager:
         return self.app.connected
 
 
-class IBKRInterface:
-    """Simplified interface for establishing and using an IBKR connection."""
+class IBKRInterfaceLegacy:
+    """Simplified legacy interface for establishing and using an IBKR connection."""
 
     def __init__(self, host: str = None, port: int = None, client_id: int = None,
                  csv_logger=None, session_id: str = None):
@@ -557,7 +557,7 @@ def test_ibkr_connection():
     """Test IBKR connection"""
     print("Testing IBKR connection...")
 
-    ib = IBKRInterface()
+    ib = IBKRInterfaceLegacy()
 
     try:
         # Start connection (paper trading port)

--- a/tsla_trading_bot.py
+++ b/tsla_trading_bot.py
@@ -19,8 +19,15 @@ from trade_logging import CSVLogger, TradeRecord, PerfSnapshot
 # Import our custom modules
 from live_data_fetcher import DataManager
 from live_strategy_engine import LiveStrategyEngine, StrategyParams, SignalType
-from ibkr_interface import IBKRInterface
+from ibkr_interface import IBKRInterface as _IBKRInterface
 from terminal_monitor import TerminalMonitor, PerformanceStats
+
+
+class IBKRInterfaceCompat(_IBKRInterface):
+    def __init__(self, *args, **kwargs):
+        # Remove legacy kwargs that old constructors don't accept
+        kwargs.pop("parent", None)
+        super().__init__(*args, **kwargs)
 
 # Configure logging
 logging.basicConfig(
@@ -131,7 +138,15 @@ class TSLATradingBot:
             # Initialize IBKR manager
             if self.config.enable_trading:
                 logger.info("Initializing IBKR connection...")
-                self.ib = IBKRInterface(
+                import inspect
+                import ibkr_interface
+
+                logging.getLogger(__name__).info(
+                    "Using IBKRInterface from %s",
+                    inspect.getsourcefile(ibkr_interface.IBKRInterface),
+                )
+
+                self.ib = IBKRInterfaceCompat(
                     host=self.config.ibkr_host,
                     port=self.config.ibkr_port,
                     client_id=self.config.ibkr_client_id,


### PR DESCRIPTION
## Summary
- Add IBKRInterfaceCompat adapter in `tsla_trading_bot` that strips legacy `parent` kwargs and log which `IBKRInterface` implementation is used.
- Rename duplicate `IBKRInterface` class to `IBKRInterfaceLegacy` in `ibkr_interface.py` to ensure the correct constructor with `parent=None` is imported.

## Testing
- `python -m py_compile tsla_trading_bot.py ibkr_interface.py`

------
https://chatgpt.com/codex/tasks/task_b_68a89a9cbafc8320a5d54294e26981d4