### PR TITLE
Load IBKR settings from environment

### DIFF
--- a/ibkr_interface.py
+++ b/ibkr_interface.py
@@ -45,11 +45,6 @@ from live_strategy_engine import TradingSignal, SignalType
 
 logger = logging.getLogger("ibkr_interface")
 
-DEFAULT_HOST = os.getenv("IBKR_HOST", "127.0.0.1")
-# 7496=LIVE TWS, 7497=PAPER TWS
-DEFAULT_PORT = int(os.getenv("IBKR_PORT", "7497"))
-DEFAULT_CLIENT_ID = int(os.getenv("IBKR_CLIENT_ID", "1"))
-
 class OrderStatus(Enum):
     PENDING = "PENDING"
     SUBMITTED = "SUBMITTED"
@@ -88,9 +83,9 @@ class IBKRInterface(EWrapper, EClient):
 
     def __init__(
         self,
-        host: str = DEFAULT_HOST,
-        port: int = DEFAULT_PORT,
-        client_id: int = DEFAULT_CLIENT_ID,
+        host: str,
+        port: int,
+        client_id: int,
         parent=None,
         **kwargs,
     ):
@@ -106,6 +101,13 @@ class IBKRInterface(EWrapper, EClient):
         self.host = host
         self.port = int(port)
         self.client_id = int(client_id)
+
+        logger.info(
+            "Connecting to IBKR at %s:%s with client ID %s",
+            self.host,
+            self.port,
+            self.client_id,
+        )
 
         self._reconnect_backoff = 2.0  # seconds
         self._max_backoff = 60.0
@@ -526,9 +528,11 @@ class IBKRInterfaceLegacy:
     def __init__(self, host: str = None, port: int = None, client_id: int = None,
                  csv_logger=None, session_id: str = None):
         # Use environment variables or defaults if parameters not provided
-        self.host = host or os.getenv("IBKR_HOST", "127.0.0.1")
-        self.port = int(port or os.getenv("IBKR_PORT", 7496))
-        self.client_id = int(client_id or os.getenv("IBKR_CLIENT_ID", 1))
+        self.host = host if host is not None else os.getenv("IBKR_HOST", "127.0.0.1")
+        self.port = int(port) if port is not None else int(os.getenv("IBKR_PORT", 7496))
+        self.client_id = (
+            int(client_id) if client_id is not None else int(os.getenv("IBKR_CLIENT_ID", 1))
+        )
 
         self._manager = IBKRManager(csv_logger=csv_logger, session_id=session_id)
 

--- a/tsla_trading_bot.py
+++ b/tsla_trading_bot.py
@@ -4,6 +4,17 @@ Main application that integrates all components for real-time trading
 """
 
 import os
+try:
+    from dotenv import load_dotenv
+    load_dotenv(override=False)  # .env fills only missing vars; shell env wins
+except Exception:
+    pass  # optional: not fatal
+
+# read config with correct precedence
+IBKR_HOST = os.getenv("IBKR_HOST", "127.0.0.1")
+IBKR_PORT = int(os.getenv("IBKR_PORT", "7496"))
+IBKR_CLIENT_ID = int(os.getenv("IBKR_CLIENT_ID", "1"))
+
 import sys
 import time
 import signal
@@ -47,9 +58,9 @@ class BotConfig:
     polygon_api_key: str = ""
     
     # IBKR Settings
-    ibkr_host: str = "127.0.0.1"
-    ibkr_port: int = 7496  # Live trading port
-    ibkr_client_id: int = 1
+    ibkr_host: str = IBKR_HOST
+    ibkr_port: int = IBKR_PORT  # Live trading port
+    ibkr_client_id: int = IBKR_CLIENT_ID
     
     # Trading Settings
     symbol: str = "TSLA"
@@ -147,9 +158,9 @@ class TSLATradingBot:
                 )
 
                 self.ib = IBKRInterfaceCompat(
-                    host=self.config.ibkr_host,
-                    port=self.config.ibkr_port,
-                    client_id=self.config.ibkr_client_id,
+                    host=IBKR_HOST,
+                    port=IBKR_PORT,
+                    client_id=IBKR_CLIENT_ID,
                     csv_logger=self.csv_logger,
                     session_id=self.session_id,
                 )
@@ -577,8 +588,9 @@ def load_config() -> BotConfig:
     
     # Load from environment variables
     config.polygon_api_key = os.getenv('POLYGON_API_KEY', 'JlAQap9qJ8F8VrfChiPmYpticVo6SMPO')
-    config.ibkr_host = os.getenv('IBKR_HOST', '127.0.0.1')
-    config.ibkr_port = int(os.getenv('IBKR_PORT', '7496'))
+    config.ibkr_host = IBKR_HOST
+    config.ibkr_port = IBKR_PORT
+    config.ibkr_client_id = IBKR_CLIENT_ID
     config.enable_trading = os.getenv('ENABLE_TRADING', 'true').lower() == 'true'
     config.max_position_size = int(os.getenv('MAX_POSITION_SIZE', str(config.max_position_size)))
 


### PR DESCRIPTION
## Summary
- Load `.env` variables at startup and derive IBKR connection settings with correct precedence.
- Pass resolved host, port, and client ID when creating `IBKRInterface`.
- Ensure `IBKRInterface` constructor keeps provided client ID and logs connection details.

## Testing
- `python -m py_compile tsla_trading_bot.py ibkr_interface.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68a8a73ad8c883208694a33bf5ec337f