### PR TITLE
Force live trading by default

### DIFF
--- a/.env
+++ b/.env
@@ -2,11 +2,11 @@
 POLYGON_API_KEY=JlAQap9qJ8F8VrfChiPmYpticVo6SMPO
 # IBKR Settings (start with paper trading)
 IBKR_HOST=127.0.0.1
-IBKR_PORT=7497
+IBKR_PORT=7496
 IBKR_CLIENT_ID=1
 
 # Trading Settings (start with paper trading)
-ENABLE_TRADING=false
+ENABLE_TRADING=true
 MAX_POSITION_SIZE=10
 MAX_DAILY_TRADES=5
 MAX_DAILY_LOSS=500.0

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Current Streak: 2
 
 ### Recommended Settings for Beginners
 ```env
-ENABLE_TRADING=true        # Enable live trading
+ENABLE_TRADING=true        # Live trading always enabled
 MAX_POSITION_SIZE=3        # Small position size
 MAX_DAILY_TRADES=3          # Conservative trade limit
 MAX_DAILY_LOSS=200.0        # Reasonable loss limit
@@ -330,7 +330,7 @@ IBKR_PORT=7496  # 7496 for live trading, 7497 for paper trading
 IBKR_CLIENT_ID=1
 
 # Trading Settings
-ENABLE_TRADING=true  # Set to false for paper trading
+ENABLE_TRADING=true  # Live trading cannot be disabled
 MAX_POSITION_SIZE=3
 MAX_DAILY_TRADES=5
 MAX_DAILY_LOSS=500.0
@@ -498,16 +498,11 @@ Built-in risk management features:
 
 ## 🧪 Testing & Development
 
-### Paper Trading Mode
+### Live Trading Mode
 
-Always test with paper trading first:
+The bot now always runs in live trading mode and forces `ENABLE_TRADING=true`:
 
 ```bash
-# Set in .env file
-ENABLE_TRADING=true
-
-# Or set environment variable
-export ENABLE_TRADING=true
 python tsla_trading_bot.py
 ```
 

--- a/tsla_trading_bot.py
+++ b/tsla_trading_bot.py
@@ -10,6 +10,9 @@ try:
 except Exception:
     pass  # optional: not fatal
 
+# Force live trading in all environments
+os.environ['ENABLE_TRADING'] = 'true'
+
 # read config with correct precedence
 IBKR_HOST = os.getenv("IBKR_HOST", "127.0.0.1")
 IBKR_PORT = int(os.getenv("IBKR_PORT", "7496"))
@@ -585,13 +588,15 @@ class TSLATradingBot:
 def load_config() -> BotConfig:
     """Load configuration from environment variables or config file"""
     config = BotConfig()
-    
+    # Force live trading regardless of external environment settings
+    os.environ['ENABLE_TRADING'] = 'true'
+    config.enable_trading = True
+
     # Load from environment variables
     config.polygon_api_key = os.getenv('POLYGON_API_KEY', 'JlAQap9qJ8F8VrfChiPmYpticVo6SMPO')
     config.ibkr_host = IBKR_HOST
     config.ibkr_port = IBKR_PORT
     config.ibkr_client_id = IBKR_CLIENT_ID
-    config.enable_trading = os.getenv('ENABLE_TRADING', 'true').lower() == 'true'
     config.max_position_size = int(os.getenv('MAX_POSITION_SIZE', str(config.max_position_size)))
 
     # CSV logging


### PR DESCRIPTION
## Summary
- Ensure `ENABLE_TRADING` is always set to `true` so the bot always runs in live mode.
- Update `.env` and README to reflect mandatory live trading configuration.

## Testing
- `python -m py_compile tsla_trading_bot.py`
- `python 'Test script to validate TSLA Trading Bot setup'` *(fails: Data Connection, IBKR Connection, Strategy Engine)*

------
https://chatgpt.com/codex/tasks/task_b_68ac9fab443c8320801c57363de5947c