### PR TITLE
Improve IBKR connection retry handling

### DIFF
--- a/ibkr_interface.py
+++ b/ibkr_interface.py
@@ -186,11 +186,15 @@ class IBKRInterface(EWrapper, EClient):
 
             if not self._api_ready.wait(timeout=max_wait_sec):
                 raise RuntimeError("API not ready (no nextValidId)")
+
             self._connected = True
             self.connected = True
+            self._reconnect_backoff = 2.0  # reset backoff after success
             return True
         except Exception as e:
             logger.error("Failed to connect and start IBKR API: %s", e)
+            # Ensure a reconnect attempt is scheduled if connection fails
+            self.schedule_reconnect()
             return False
         finally:
             self._is_connecting = False


### PR DESCRIPTION
## Summary
- reset reconnect backoff after successful IBKR connection
- schedule reconnection when API readiness fails to obtain nextValidId

## Testing
- `python -m py_compile ibkr_interface.py`
- `ENABLE_TRADING=false python 'Test script to validate TSLA Trading Bot setup'` *(fails: data connection, strategy engine)*

------
https://chatgpt.com/codex/tasks/task_b_68adfe976b948320a24392434cf5af17