### PR TITLE
Handle reconnects only when not already connecting

### DIFF
--- a/ibkr_interface.py
+++ b/ibkr_interface.py
@@ -215,6 +215,9 @@ class IBKRInterface(EWrapper, EClient):
         logger.warning("IBKR connection lost. Attempting to reconnect in %.1fs...", backoff)
 
         def _reconnect():
+            if self._is_connecting:
+                self.schedule_reconnect()
+                return
             try:
                 self.disconnect_safe()
             except Exception:
@@ -236,7 +239,8 @@ class IBKRInterface(EWrapper, EClient):
 
             # Update connection parameters and reconnect
             self.host, self.port, self.client_id = host, port, client_id
-            self.connect_and_start()
+            if not self._is_connecting:
+                self.connect_and_start()
 
         self._reconnect_timer = threading.Timer(backoff, _reconnect)
         self._reconnect_timer.daemon = True

--- a/tests/test_ibkr_reconnect.py
+++ b/tests/test_ibkr_reconnect.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import threading
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from ibkr_interface import IBKRInterface
+
+
+def test_reconnect_defers_during_connect():
+    interface = IBKRInterface('host', 1, 1)
+    calls = {'disconnect': 0, 'connect': 0}
+
+    def fake_disconnect():
+        calls['disconnect'] += 1
+
+    def fake_connect():
+        calls['connect'] += 1
+
+    interface.disconnect_safe = fake_disconnect
+    interface.connect_and_start = fake_connect
+
+    callbacks = []
+
+    class FakeTimer:
+        def __init__(self, interval, func):
+            self.interval = interval
+            self.func = func
+            self.daemon = True
+        def start(self):
+            callbacks.append(self.func)
+        def is_alive(self):
+            return False
+
+    original_timer = threading.Timer
+    threading.Timer = FakeTimer
+    try:
+        interface._is_connecting = True
+        interface.schedule_reconnect()
+        # first scheduled reconnect while still connecting
+        callbacks.pop(0)()
+        assert calls['connect'] == 0
+        assert calls['disconnect'] == 0
+        # simulate connection attempt finished
+        interface._is_connecting = False
+        callbacks.pop(0)()
+        assert calls['connect'] == 1
+        assert calls['disconnect'] == 1
+        assert callbacks == []
+    finally:
+        threading.Timer = original_timer


### PR DESCRIPTION
## Summary
- prevent reconnection logic from running while a connection attempt is ongoing
- add unit test ensuring reconnect is rescheduled when `_is_connecting` is true and connects only once

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ae011f2a008320952793f438664f9d