### PR TITLE
Continue initialization when IBKR connection fails

### DIFF
--- a/tsla_trading_bot.py
+++ b/tsla_trading_bot.py
@@ -168,8 +168,9 @@ class TSLATradingBot:
                     session_id=self.session_id,
                 )
                 if not self.ib.connect_and_start():
-                    logger.error("Failed to connect to IBKR")
-                    return False
+                    logger.warning(
+                        "Initial IBKR connection failed; retrying in background"
+                    )
             else:
                 logger.info("Trading disabled - running in simulation mode")
             


### PR DESCRIPTION
## Summary
- Don't abort bot initialization when the first IBKR connection attempt fails
- Warn that the connection failed and rely on the reconnect timer to retry

## Testing
- `python -m py_compile tsla_trading_bot.py`
- Simulated connection failure: bot started main loop and reconnect succeeded

------
https://chatgpt.com/codex/tasks/task_b_68ae011006d88320bdb0a7ee5d10d732